### PR TITLE
replace runInContext by runInNewContext

### DIFF
--- a/src/handlers/executor.js
+++ b/src/handlers/executor.js
@@ -18,7 +18,7 @@ module.exports = function executor(sourceFile, expression, model, skipTranslate,
         log = profiler.start('executor', 'cache hit');
     }
 
-    var result = cachedExpression.runInContext(model, { filename: sourceFile });
+    var result = cachedExpression.runInNewContext(model, { filename: sourceFile });
     log.end();
     return result;
 };


### PR DESCRIPTION
I think this is a bug but I'm not sure.
Have some errors when I run the follow codes in my test script.

// render
var filePath = path.resolve(__dirname, 'examples/test.jsp');
var content = fs.readFileSync(filePath);
var model = { foo: 'bar', oy: 'vey' };
parser
    .parseContent(content.toString())
    .then(function(dom){
        return renderer.renderNodes(filePath, dom, model, null, profile);
    }).then(function(){
        console.log(arguments);
    });

Potentially unhandled rejection [2] {"message":"error executing expression","expression":"oy","model":{"foo":"bar","oy":"vey"},"ex":{"message":"
needs a 'context' argument."}} (WARNING: non-Error used)

And I found the renderNodes will call the vm.createContext everytime, so I replace runInContext by runInNewContext and it's work!!
